### PR TITLE
fix(ci): resolve SEO tracking job exit 127 — env block YAML indentation

### DIFF
--- a/.github/workflows/seo-audit.yml
+++ b/.github/workflows/seo-audit.yml
@@ -1053,6 +1053,11 @@ jobs:
         name: seo-comprehensive-report
 
     - name: Update SEO Metrics
+      env:
+        OVERALL_SCORE: ${{ needs.seo-report.outputs.overall-score }}
+        TECHNICAL_SCORE: ${{ needs.seo-report.outputs.technical-score }}
+        TOTAL_ISSUES: ${{ needs.seo-report.outputs.total-issues }}
+        HIGH_SEVERITY_ISSUES: ${{ needs.seo-report.outputs.high-severity-issues }}
       run: |
         cat > update-metrics.cjs << 'EOF'
         // This would integrate with your analytics/monitoring system
@@ -1083,11 +1088,6 @@ jobs:
         EOF
         
         node update-metrics.cjs
-        env:
-          OVERALL_SCORE: ${{ needs.seo-report.outputs.overall-score }}
-          TECHNICAL_SCORE: ${{ needs.seo-report.outputs.technical-score }}
-          TOTAL_ISSUES: ${{ needs.seo-report.outputs.total-issues }}
-          HIGH_SEVERITY_ISSUES: ${{ needs.seo-report.outputs.high-severity-issues }}
 
     - name: Archive SEO History
       run: |


### PR DESCRIPTION
## Summary

Fixes a YAML indentation bug in `seo-audit.yml` that caused the `SEO Performance Tracking` job to fail on **every execution** with exit code 127 (`env:: command not found`).

---

## Problem

The `env:` block in the `Update SEO Metrics` step (job `seo-tracking`) was indented as part of the `run:` multiline string instead of being declared as a step-level key.

GitHub Actions YAML requires `env:`, `with:`, and `if:` to be **siblings** of `run:` — not children. Because `env:` was inside the heredoc shell context, bash received it as a literal command to execute:

```
/home/runner/work/_temp/xxx.sh: line 30: env:: command not found
Error: Process completed with exit code 127.
```

This failure occurred on:
- Every `push` to `main`
- Every scheduled run (daily at 3 AM UTC)

## Root Cause

```yaml
# BEFORE (broken) — env: is indented inside run:, treated as shell content
- name: Update SEO Metrics
  run: |
    cat > update-metrics.cjs << 'EOF'
    ...
    EOF
    node update-metrics.cjs
    env:                                          # bash executes "env:" → exit 127
      OVERALL_SCORE: ${{ needs.seo-report.outputs.overall-score }}
      TECHNICAL_SCORE: ${{ needs.seo-report.outputs.technical-score }}
      TOTAL_ISSUES: ${{ needs.seo-report.outputs.total-issues }}
      HIGH_SEVERITY_ISSUES: ${{ needs.seo-report.outputs.high-severity-issues }}
```

## Fix

```yaml
# AFTER (correct) — env: is a step-level key, evaluated by the runner before execution
- name: Update SEO Metrics
  env:
    OVERALL_SCORE: ${{ needs.seo-report.outputs.overall-score }}
    TECHNICAL_SCORE: ${{ needs.seo-report.outputs.technical-score }}
    TOTAL_ISSUES: ${{ needs.seo-report.outputs.total-issues }}
    HIGH_SEVERITY_ISSUES: ${{ needs.seo-report.outputs.high-severity-issues }}
  run: |
    cat > update-metrics.cjs << 'EOF'
    ...
    EOF
    node update-metrics.cjs
```

## Change

| | |
|-|-|
| **File** | `.github/workflows/seo-audit.yml` |
| **Lines changed** | 5 moved (no logic changes) |
| **Risk** | Low — structural YAML fix only |

## Test Plan

- [ ] Push triggers `Advanced SEO Audit & Analysis` workflow on `main`
- [ ] `SEO Performance Tracking` job completes successfully (no exit 127)
- [ ] `update-metrics.cjs` receives `OVERALL_SCORE`, `TECHNICAL_SCORE`, `TOTAL_ISSUES`, `HIGH_SEVERITY_ISSUES` from the runner environment
- [ ] Scheduled run (3 AM UTC) passes without error
